### PR TITLE
fix compile error

### DIFF
--- a/FlappyBird/app/src/main/jni/game.c
+++ b/FlappyBird/app/src/main/jni/game.c
@@ -9,6 +9,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <math.h>
+#include <string.h>
 
 #define SIZE_SPACE_PIPE 3.3f
 


### PR DESCRIPTION
when I use ndk 27.0.12077973. it complain: 
```
jni/game.c:388:15: error: call to undeclared library function 'strlen' with type 'unsigned int (const char *)'; ISO C99
      and later do not support implicit function declarations [-Wimplicit-function-declaration]
  388 |     int len = strlen(scoreStr);
      |               ^
jni/game.c:388:15: note: include the header <string.h> or explicitly provide a declaration for 'strlen'
```