### PR TITLE
Fix broken star history chart in READMEs

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ I do not claim any copyright. The rights to the game and resources belong to **D
 
 ## 🌠 Star History
 
-[![Star History Chart](https://api.star-history.com/svg?repos=VadimBoev/FlappyBird&type=Timeline)](https://star-history.com/#VadimBoev/FlappyBird&Timeline)
+[![Star History Chart](https://star-history.dera.page/svg?repos=VadimBoev/FlappyBird&type=Timeline)](https://star-history.dera.page/#VadimBoev/FlappyBird&Timeline)
 
 ---
 

--- a/README_RU.md
+++ b/README_RU.md
@@ -63,7 +63,7 @@
 
 ## 🌠 Star History
 
-[![Star History Chart](https://api.star-history.com/svg?repos=VadimBoev/FlappyBird&type=Timeline)](https://star-history.com/#VadimBoev/FlappyBird&Timeline)
+[![Star History Chart](https://star-history.dera.page/svg?repos=VadimBoev/FlappyBird&type=Timeline)](https://star-history.dera.page/#VadimBoev/FlappyBird&Timeline)
 
 ---
 


### PR DESCRIPTION
The star history chart on the README pages is currently broken and displays no data, since the upstream service no longer serves it. This change points the chart to a working endpoint so visitors can see the project's star history again. The chart was originally added in 1d6b7cf and 0491242.